### PR TITLE
Try to fix PTBUserWarning: No `JobQueue` set up

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy==1.25.2
 pandas==2.0.3
 python-dotenv==1.0.0
 python-telegram-bot==20.4
+python-telegram-bot[job-queue]==20.4
 pytz==2023.3
 ta==0.10.2
 cryptography==3.4.6


### PR DESCRIPTION
Try to fix PTBUserWarning: No `JobQueue` set up. To use `JobQueue`, you must install PTB via `pip install "python-telegram-bot[job-queue]"`.